### PR TITLE
Ri/feature/subgraph editor

### DIFF
--- a/components/CodeEditor.tsx
+++ b/components/CodeEditor.tsx
@@ -11,6 +11,7 @@ interface EditorProps {
   defaultValue: string
   fileId: string
   onMount?: (editor: any, monaco: any) => void
+  defaultLanguage?: 'typescript' | 'graphql'
 }
 
 const Editor: React.FC<EditorProps> = ({
@@ -19,6 +20,7 @@ const Editor: React.FC<EditorProps> = ({
   defaultValue,
   fileId,
   onMount,
+  defaultLanguage = 'typescript',
 }) => {
   const code = useRef(defaultValue)
   const monaco = useMonaco()
@@ -64,12 +66,13 @@ const Editor: React.FC<EditorProps> = ({
   return (
     <MonacoEditor
       theme="vs-dark"
-      defaultLanguage="typescript"
+      defaultLanguage={defaultLanguage}
       defaultValue={defaultValue}
       path={fileId}
       options={{
         tabSize: 2,
         insertSpaces: true,
+        minimap: { enabled: false },
       }}
       onMount={(editor: any) => {
         if (onMount) {

--- a/components/SubgraphEditor/BottomTitleBar.tsx
+++ b/components/SubgraphEditor/BottomTitleBar.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Top } from 'react-spaces'
+import CloseIcon from 'components/CloseIcon'
+import { useConsole } from 'hooks/console'
+
+const Header = styled(Top)`
+  background: #2f2f2f;
+  border-bottom: solid 1px #4a4a4d;
+  border-top: solid 1px #4a4a4d;
+  display: flex;
+  padding: 0 4px;
+  align-items: center;
+  justify-content: space-between;
+  color: #ffffff;
+`
+
+const CloseButton = styled.button`
+  border: none;
+  background: transparent;
+  margin-left: 10px;
+  cursor: pointer;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+
+  & svg {
+    fill: #888888;
+  }
+  &:hover svg {
+    fill: #666666;
+  }
+`
+
+const ClearButton = styled.button`
+  height: 20px;
+  padding: 3px 0 2px;
+  border-radius: 4px;
+  border: solid 1px #ffffff;
+  background-color: transparent;
+  margin: 16px 0 6px;
+  color: white;
+  padding: 2px 16px;
+  margin-left: 8px;
+
+  &:hover {
+    background: #363636;
+  }
+`
+
+export enum BottomView {
+  NONE,
+  ERRORS,
+  CONSOLE,
+}
+
+interface BottomTitleBarProps {
+  view: BottomView
+  onSetView: (newView: BottomView) => void
+}
+
+const BottomTitleBar: React.FC<BottomTitleBarProps> = ({ view, onSetView }) => {
+  const { clear: clearConsole } = useConsole()
+
+  return (
+    <Header size={40}>
+      <div>
+        {view === BottomView.ERRORS ? 'Errors' : 'Console'}
+        {view === BottomView.CONSOLE && <ClearButton onClick={clearConsole}>Clear</ClearButton>}
+      </div>
+
+      <CloseButton onClick={() => onSetView(BottomView.NONE)}>
+        <CloseIcon />
+      </CloseButton>
+    </Header>
+  )
+}
+
+export default BottomTitleBar

--- a/components/SubgraphEditor/Console.tsx
+++ b/components/SubgraphEditor/Console.tsx
@@ -1,0 +1,41 @@
+import React, { useLayoutEffect, useRef } from 'react'
+import styled from 'styled-components'
+import { Fill } from 'react-spaces'
+import { useConsole, Line } from 'hooks/console'
+import { LOG_LEVEL } from '@cryptostats/sdk'
+
+const ConsoleView = styled(Fill)`
+  padding: 8px;
+  color: #ffffff;
+  font-size: 12px;
+`
+
+const ConsoleLine = styled.div<{ level: string }>`
+  font-family: monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+
+  ${({ level }) => (level === LOG_LEVEL.ERROR.toString() ? 'color: red;' : '')}
+`
+
+const Console: React.FC = () => {
+  const { lines } = useConsole()
+  const bottomRef = useRef<any>(null)
+
+  useLayoutEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [bottomRef.current, lines])
+
+  return (
+    <ConsoleView scrollable={true}>
+      {lines.map((line: Line, i: number) => (
+        <ConsoleLine key={i} level={line.level}>
+          {line.value}
+        </ConsoleLine>
+      ))}
+      <div ref={bottomRef} />
+    </ConsoleView>
+  )
+}
+
+export default Console

--- a/components/SubgraphEditor/Editor.tsx
+++ b/components/SubgraphEditor/Editor.tsx
@@ -1,0 +1,360 @@
+import React, { useState, useEffect, useRef } from 'react'
+import { ViewPort, Top, Fill, Bottom, BottomResizable, Right } from 'react-spaces'
+import { useRouter } from 'next/router'
+import { LOG_LEVEL } from '@cryptostats/sdk'
+import { useWeb3React } from '@web3-react/core'
+import styled from 'styled-components'
+import { useENSName } from 'use-ens-name'
+import CodeEditor from 'components/CodeEditor'
+import ConnectionButton from 'components/ConnectionButton'
+import { useSubgraph, newModule, getStorageItem, FileData } from 'hooks/local-subgraphs'
+import { useCompiler } from 'hooks/compiler'
+import { useConsole } from 'hooks/console'
+import { emptyMapping, emptySchema } from 'resources/templates'
+import PrimaryFooter from './PrimaryFooter'
+import { Tabs, TabState } from './Tabs'
+import EditorModal from './EditorModal'
+import NewAdapterForm from './NewAdapterForm'
+import { MarkerSeverity } from './types'
+import ErrorPanel from './ErrorPanel'
+import { usePlausible } from 'next-plausible'
+import { useEditorState } from '../../hooks/editor-state'
+import EditorControls from './EditorControls'
+import Console from './Console'
+import BottomTitleBar, { BottomView } from './BottomTitleBar'
+import SaveMessage from './SaveMessage'
+import ImageLibrary from './ImageLibrary/ImageLibrary'
+
+const Header = styled(Top)`
+  background-image: url('/editor_logo.png');
+  background-size: 140px;
+  background-color: #2f2f2f;
+  background-position: center;
+  background-repeat: no-repeat;
+  border-bottom: solid 1px #4a4a4d;
+  display: flex;
+  justify-content: space-between;
+`
+
+const HeaderRight = styled.div`
+  display: flex;
+  align-items: center;
+
+  @media (max-width: 700px) {
+    display: none;
+  }
+`
+
+const CloseButton = styled.button`
+  background: none;
+  border: none;
+  font-size: 12px;
+  font-weight: 600;
+  color: white;
+  margin-left: 16px;
+
+  &:hover {
+    cursor: pointer;
+  }
+`
+
+const NewAdapterButton = styled.button`
+  height: 35px;
+  border: solid 1px;
+  background: transparent;
+  border: solid 1px #0477f4;
+  color: #0477f4;
+  margin: 0 10px;
+  padding: 0 10px;
+  border-radius: 5px;
+  cursor: pointer;
+
+  &:hover {
+    background: #0477f430;
+  }
+`
+
+const WalletButton = styled(ConnectionButton)`
+  height: 35px;
+  border-radius: 5px;
+  border: solid 1px #7b7b7b;
+  background-color: #535353;
+  padding: 0 10px;
+  color: #eeeeee;
+  margin-right: 10px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #404040;
+  }
+`
+
+const TabContainer = styled(Top)`
+  background-color: #2f2f2f;
+
+  & > .spaces-space > div {
+    display: flex;
+  }
+`
+
+const PrimaryFooterContainer = styled(Bottom)`
+  border-top: solid 1px #444447;
+  display: flex;
+  background: #2f2f2f;
+`
+
+const FillWithStyledResize = styled(Fill)<{ side: string }>`
+  > .spaces-resize-handle {
+    ${({ side }) => 'border-' + side}: solid 2px #4a4a4d;
+    box-sizing: border-box;
+  }
+`
+
+const PrimaryFill = styled(FillWithStyledResize)`
+  @media (max-width: 700px) {
+    & > * {
+      display: none;
+    }
+
+    &:before {
+      content: 'The CryptoStats editor is not available on mobile devices 😢';
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      margin: 32px;
+      font-size: 24px;
+      text-align: center;
+    }
+  }
+`
+
+const formatLog = (val: any) => {
+  if (val.toString() === '[object Object]') {
+    return JSON.stringify(val, null, 2)
+  } else if (typeof val === 'string') {
+    return `"${val}"`
+  }
+  return val.toString()
+}
+
+const Editor: React.FC = () => {
+  const router = useRouter()
+  const plausible = usePlausible()
+  const [subgraphFiles, setSubgraphFiles] = useEditorState<TabState[] | []>(
+    'test',
+    [
+      { type: 'schema', fileId: null, open: true, focused: true },
+      { type: 'mapping', fileId: null, open: true, focused: false },
+    ],
+    'subgraph-editor-state'
+  )
+  const { save } = useSubgraph()
+
+  const openTabs = (subgraphFiles || [])
+    .filter(sgf => sgf.open)
+    .map(ot => ({ ...ot, ...(ot.fileId && { fileData: getStorageItem(ot.fileId) as FileData }) }))
+  const focusedTab = openTabs?.find(sgf => sgf.focused)!
+
+  useEffect(() => {
+    setSubgraphFiles((prev: TabState[]) =>
+      prev.map(pi =>
+        pi.open && !pi.fileId
+          ? {
+              ...pi,
+              fileId: newModule(
+                pi?.type === 'schema'
+                  ? { code: emptySchema, name: 'New Schema' }
+                  : { code: emptyMapping, name: 'New Mapping' }
+              ),
+            }
+          : pi
+      )
+    )
+  }, [])
+
+  const [started, setStarted] = useState(false)
+  const [newAdapterModalOpen, setNewAdapterModalOpen] = useState(false)
+  const [markers, setMarkers] = useState<any[]>([])
+  const [imageLibraryOpen, setImageLibraryOpen] = useState(false)
+  const [bottomView, setBottomView] = useState(BottomView.NONE)
+  const editorRef = useRef<any>(null)
+
+  const { evaluate, module } = useCompiler()
+  const { addLine } = useConsole()
+  const { account } = useWeb3React()
+  const name = useENSName(account)
+
+  // useEffect(() => {
+  //   if (router.query.adapter) {
+  //     const { adapter, ...query } = router.query
+  //     setFileName(adapter as string)
+  //     router.replace({ pathname: '/editor', query })
+  //   }
+  // }, [router.query])
+
+  useEffect(() => {
+    if (imageLibraryOpen) {
+      plausible('open-image-library')
+    }
+  }, [imageLibraryOpen])
+
+  useEffect(() => {
+    setStarted(true)
+  }, [])
+  if (!started) {
+    return null
+  }
+
+  const saveCode = (code: string) =>
+    save(focusedTab.fileId!, code, focusedTab.fileData!.name, focusedTab.fileData!.version)
+
+  return (
+    <ViewPort style={{ background: '#0f1011' }}>
+      <Header size={64} order={1}>
+        <SaveMessage />
+
+        <CloseButton onClick={() => router.push('/discover')}>X Close</CloseButton>
+
+        <HeaderRight>
+          <NewAdapterButton onClick={() => setNewAdapterModalOpen(true)}>
+            New Adapter
+          </NewAdapterButton>
+          <WalletButton>{account ? name || account.substr(0, 10) : 'Connect Wallet'}</WalletButton>
+        </HeaderRight>
+      </Header>
+      <PrimaryFill side="right">
+        <Fill>
+          <FillWithStyledResize side="left">
+            <Fill>
+              <TabContainer size={50}>
+                <Fill>
+                  <Tabs
+                    openTabs={openTabs}
+                    current={focusedTab.fileData?.name}
+                    onSelect={fileId =>
+                      setSubgraphFiles(prev =>
+                        prev.map(p => ({ ...p, focused: p.fileId === fileId }))
+                      )
+                    }
+                  />
+                </Fill>
+                <Right size={100}>
+                  <EditorControls editorRef={editorRef} />
+                </Right>
+              </TabContainer>
+
+              <Fill>
+                {focusedTab?.fileData ? (
+                  <CodeEditor
+                    defaultLanguage={focusedTab.type === 'schema' ? 'graphql' : 'typescript'}
+                    fileId={focusedTab.fileId!}
+                    defaultValue={focusedTab?.fileData?.code}
+                    onMount={(editor: any) => {
+                      editorRef.current = editor
+                    }}
+                    onChange={saveCode}
+                    onValidated={(code: string, markers: any[]) => {
+                      setMarkers(markers)
+
+                      if (
+                        markers.filter((marker: any) => marker.severity === MarkerSeverity.Error)
+                          .length === 0
+                      ) {
+                        evaluate({
+                          code,
+                          isTS: true,
+                          onLog: (level: LOG_LEVEL, ...args: any[]) =>
+                            addLine({
+                              level: level.toString(),
+                              value: args.map(formatLog).join(' '),
+                            }),
+                        })
+                      }
+                    }}
+                  />
+                ) : (
+                  <div>test</div>
+                )}
+              </Fill>
+
+              {bottomView !== BottomView.NONE && (
+                <BottomResizable size={160} minimumSize={60} maximumSize={300}>
+                  <Top size={42}>
+                    <BottomTitleBar view={bottomView} onSetView={setBottomView} />
+                  </Top>
+                  <Fill>
+                    {bottomView === BottomView.ERRORS ? (
+                      <ErrorPanel
+                        markers={markers}
+                        onClose={() => setBottomView(BottomView.NONE)}
+                      />
+                    ) : (
+                      <Console />
+                    )}
+                  </Fill>
+                </BottomResizable>
+              )}
+            </Fill>
+
+            {/* <RightResizable size={443}>
+              <RightPanel />
+            </RightResizable> */}
+          </FillWithStyledResize>
+
+          <PrimaryFooterContainer size={55}>
+            {focusedTab?.fileData ? (
+              <PrimaryFooter
+                fileName={focusedTab?.fileData.name}
+                markers={markers}
+                onMarkerClick={() => setBottomView(BottomView.ERRORS)}
+                onConsoleClick={() => setBottomView(BottomView.CONSOLE)}
+                editorRef={editorRef}
+              />
+            ) : null}
+          </PrimaryFooterContainer>
+        </Fill>
+      </PrimaryFill>
+
+      <ImageLibrary
+        open={imageLibraryOpen}
+        close={() => setImageLibraryOpen(false)}
+        editor={editorRef.current}
+      />
+
+      <EditorModal
+        isOpen={newAdapterModalOpen}
+        onClose={() => setNewAdapterModalOpen(false)}
+        title="Create new adapter"
+        buttons={[
+          {
+            label: 'Return to Editor',
+            onClick: () => setNewAdapterModalOpen(false),
+          },
+          {
+            label: 'Create Blank Adapter',
+            onClick: () => {
+              plausible('new-adapter', {
+                props: {
+                  template: 'blank',
+                },
+              })
+
+              // setMappingFileName(newModule(emptyMapping))
+              setNewAdapterModalOpen(false)
+            },
+          },
+        ]}>
+        <NewAdapterForm
+          onAdapterSelection={(fileName: string) => {
+            // setMappingFileName(fileName)
+            setNewAdapterModalOpen(false)
+          }}
+        />
+      </EditorModal>
+    </ViewPort>
+  )
+}
+
+export default Editor

--- a/components/SubgraphEditor/Editor.tsx
+++ b/components/SubgraphEditor/Editor.tsx
@@ -181,7 +181,7 @@ const Editor: React.FC = () => {
   const [bottomView, setBottomView] = useState(BottomView.NONE)
   const editorRef = useRef<any>(null)
 
-  const { evaluate, module } = useCompiler()
+  const { evaluate } = useCompiler()
   const { addLine } = useConsole()
   const { account } = useWeb3React()
   const name = useENSName(account)
@@ -347,7 +347,7 @@ const Editor: React.FC = () => {
           },
         ]}>
         <NewAdapterForm
-          onAdapterSelection={(fileName: string) => {
+          onAdapterSelection={(_fileName: string) => {
             // setMappingFileName(fileName)
             setNewAdapterModalOpen(false)
           }}

--- a/components/SubgraphEditor/EditorControls.tsx
+++ b/components/SubgraphEditor/EditorControls.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useRef, useState } from 'react'
+import styled from 'styled-components'
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 16px;
+`
+
+const Button = styled.button`
+  display: flex;
+  width: 24px;
+  height: 24px;
+  padding: 4px;
+  background: transparent;
+  border: none;
+  align-items: stretch;
+  color: #acabab;
+  margin: 4px;
+  border-radius: 50%;
+  cursor: pointer;
+
+  &:disabled {
+    color: #4a4a4a;
+    cursor: unset;
+  }
+
+  &:hover {
+    background: #444;
+  }
+
+  &:hover:disabled {
+    background: transparent;
+  }
+`
+
+const EditorControls: React.FC<{ editorRef: any }> = ({ editorRef }) => {
+  const versions = useRef({
+    currentVersion: 0,
+    initialVersion: 0,
+    lastVersion: 0,
+  })
+  const [undoEnabled, setUndoEnabled] = useState(false)
+  const [redoEnabled, setRedoEnabled] = useState(false)
+
+  useEffect(() => {
+    if (editorRef.current) {
+      versions.current.initialVersion = editorRef.current.getModel().getAlternativeVersionId()
+
+      const disposable = editorRef.current.onDidChangeModelContent(() => {
+        const versionId = editorRef.current.getModel().getAlternativeVersionId()
+        const { currentVersion, initialVersion, lastVersion } = versions.current
+
+        // undoing
+        if (versionId < currentVersion) {
+          setRedoEnabled(true)
+          // no more undo possible
+          if (versionId === initialVersion) {
+            setUndoEnabled(false)
+          }
+        } else {
+          // redoing
+          if (versionId <= lastVersion) {
+            // redoing the last change
+            if (versionId == lastVersion) {
+              setRedoEnabled(false)
+            }
+          } else {
+            // adding new change, disable redo when adding new changes
+            setRedoEnabled(false)
+            if (currentVersion > lastVersion) {
+              versions.current.lastVersion = currentVersion
+            }
+          }
+          setUndoEnabled(true)
+        }
+        versions.current.currentVersion = versionId
+      })
+      return () => disposable.dispose()
+    }
+  }, [editorRef.current])
+
+  return (
+    <Container>
+      <Button disabled={!undoEnabled} onClick={() => editorRef.current.trigger('controls', 'undo')}>
+        <svg
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          version="1.1"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polyline transform="translate(1.2578 5.4846)" points="1 4 1 10 7 10" />
+          <path d="m21.748 14.485c-2.2082-6.2402-10.171-8.0418-14.85-3.36l-4.64 4.36" />
+        </svg>
+      </Button>
+
+      <Button disabled={!redoEnabled} onClick={() => editorRef.current.trigger('controls', 'redo')}>
+        <svg
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          version="1.1"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polyline transform="matrix(-1 0 0 1 22.742 5.4846)" points="1 4 1 10 7 10" />
+          <path d="m2.2522 14.485c2.2082-6.2402 10.171-8.0418 14.85-3.36l4.64 4.36" />
+        </svg>
+      </Button>
+    </Container>
+  )
+}
+
+export default EditorControls

--- a/components/SubgraphEditor/EditorModal.tsx
+++ b/components/SubgraphEditor/EditorModal.tsx
@@ -1,0 +1,158 @@
+import React from 'react'
+import styled from 'styled-components'
+import ReactModal from 'react-modal'
+import ButtonComponent from '../Button'
+import { ChevronLeft, X } from 'react-feather'
+
+const ModalOverlay = styled.div<{ width?: string | number; height?: string | number }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: transparent !important;
+
+  &:before {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7) !important;
+    backdrop-filter: blur(4px);
+    z-index: 1;
+  }
+
+  & .modal-content {
+    z-index: 2;
+    border: solid 1px #444;
+    border-radius: 4px;
+    background-color: #2f2f2f;
+    color: #c8c8c8;
+    margin: 40px;
+    display: flex;
+    flex-direction: column;
+    ${({ width, height }) => `
+      ${width ? `width: ${width};` : ''}
+      ${height ? `height: ${height};` : ''}
+    `}
+  }
+`
+
+const Header = styled.h1`
+  color: #ffffff;
+  font-size: 18px;
+  font-weight: 600;
+  border-bottom: solid 1px #444;
+  padding: 32px;
+  text-align: center;
+`
+
+const Footer = styled.div`
+  display: flex;
+  border-top: solid 1px #444;
+  padding: 24px 30px;
+  justify-content: space-between;
+`
+
+const Content = styled.div`
+  max-height: 70vh;
+  padding: 32px;
+  overflow: auto;
+  flex: 1;
+`
+
+const HeaderSide = styled.div<{ side: string }>`
+  width: 32px;
+  float: ${({ side }) => side};
+  text-align: ${({ side }) => side};
+`
+
+const HeaderButton = styled.button`
+  background: none;
+  border: none;
+  color: #cccccc;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+
+  &:hover {
+    background: #444444;
+  }
+`
+
+ReactModal.setAppElement('#__next')
+
+export interface Button {
+  label: string
+  onClick: () => void
+  disabled?: boolean
+}
+
+interface ModalProps {
+  isOpen: boolean
+  onClose: () => void
+  title: string
+  buttons: Button[]
+  width?: string
+  height?: string
+  onBack?: null | (() => void)
+}
+
+const EditorModal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  buttons,
+  children,
+  width,
+  height,
+  onBack,
+}) => {
+  return (
+    <ReactModal
+      isOpen={isOpen}
+      onRequestClose={onClose}
+      contentLabel={title}
+      className="modal-content"
+      overlayElement={(props: any, contentElement: any) => (
+        <ModalOverlay width={width} height={height} {...props}>
+          {contentElement}
+        </ModalOverlay>
+      )}
+    >
+      <Header>
+        <HeaderSide side="left">
+          {onBack && (
+            <HeaderButton onClick={onBack}>
+              <ChevronLeft />
+              Back
+            </HeaderButton>
+          )}
+        </HeaderSide>
+
+        {title}
+
+        <HeaderSide side="right">
+          <HeaderButton onClick={onClose}>
+            <X />
+          </HeaderButton>
+        </HeaderSide>
+      </Header>
+
+      <Content>{children}</Content>
+
+      <Footer>
+        {buttons.map(button => (
+          <ButtonComponent
+            key={button.label}
+            onClick={button.onClick}
+            disabled={button.disabled}
+            variant={button.label === 'Return to Editor' ? 'outline' : 'primary'}
+          >
+            {button.label}
+          </ButtonComponent>
+        ))}
+      </Footer>
+    </ReactModal>
+  )
+}
+
+export default EditorModal

--- a/components/SubgraphEditor/EmptyState.tsx
+++ b/components/SubgraphEditor/EmptyState.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const OuterContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  color: #ffffff;
+  margin: 20px;
+  max-width: 400px;
+  text-align: center;
+`
+
+const GM = styled.h3`
+  font-size: 24px;
+  font-weight: bold;
+`
+
+const P = styled.p<{ bold?: boolean }>`
+  font-size: 18px;
+  ${({ bold }) => bold && 'font-weight: bold;'}
+`
+
+const Button = styled.button`
+  border: solid 1px #0477f4;
+  border-radius: 4px;
+  color: #0477f4;
+  font-size: 14px;
+  font-weight: 500;
+  background: transparent;
+  height: 36px;
+
+  &:hover {
+    background: #011932;
+  }
+`
+
+interface EmptyStateProps {
+  onCreate: () => void
+}
+
+const EmptyState: React.FC<EmptyStateProps> = ({ onCreate }) => {
+  return (
+    <OuterContainer>
+      <Container>
+        <GM>Gm</GM>
+
+        <P>Create, test, and publish CryptoStats adapters. All from your browser!</P>
+
+        <P bold>Let's get started!</P>
+
+        <Button onClick={onCreate}>Create new adapter</Button>
+      </Container>
+    </OuterContainer>
+  )
+}
+
+export default EmptyState

--- a/components/SubgraphEditor/ErrorPanel.tsx
+++ b/components/SubgraphEditor/ErrorPanel.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { Fill } from 'react-spaces'
+import styled from 'styled-components'
+
+const MarkerList = styled.ul`
+  color: #c8c8c8;
+  padding: 0;
+  margin: 0;
+`
+
+const MarkerRow = styled.li`
+  list-style: none;
+  display: flex;
+  align-items: center;
+  padding: 4px;
+  border-bottom: solid 1px #333333;
+  height: 30px;
+  font-size: 14px;
+`
+
+const Line = styled.span`
+  color: #999999;
+  padding-right: 4px;
+`
+
+const EmptyState = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #c8c8c8;
+`
+
+interface ErrorPanelProps {
+  markers: any[]
+  onClose: () => void
+}
+
+const ErrorPanel: React.FC<ErrorPanelProps> = ({ markers }) => {
+  return (
+    <Fill>
+      {markers.length > 0 ? (
+        <MarkerList>
+          {markers.map(marker => (
+            <MarkerRow key={`${marker.startLineNumber}-${marker.startColumn}-${marker.code}`}>
+              <Line>
+                [{marker.startLineNumber}:{marker.startColumn}]
+              </Line>
+              {marker.message}
+            </MarkerRow>
+          ))}
+        </MarkerList>
+      ) : (
+        <EmptyState>No Errors</EmptyState>
+      )}
+    </Fill>
+  )
+}
+
+export default ErrorPanel

--- a/components/SubgraphEditor/ImageLibrary/ImageGalery.tsx
+++ b/components/SubgraphEditor/ImageLibrary/ImageGalery.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react'
+import { useImages } from 'hooks/images'
+import styled, { css, keyframes } from 'styled-components'
+import FileUploadButton from 'components/FileUploadButton'
+import { IPFS_GATEWAY } from 'resources/constants'
+
+const Cards = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+`
+
+const Card = styled.li`
+  display: flex;
+  flex-direction: column;
+  width: 150px;
+  height: 150px;
+  padding: 40px;
+  border-radius: 5px;
+  border: solid 1px #595959;
+  margin: 12px;
+  cursor: pointer;
+  box-sizing: border-box;
+
+  &:hover {
+    background: #333333;
+  }
+`
+
+const UploadCard = styled(Card)`
+  padding: 0;
+`
+
+const spin = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+`
+
+const loadingMixin = css`
+  cursor: default;
+
+  &:before {
+    content: '';
+    background: none;
+    border: 6px solid #aaa;
+    border-color: #aaa transparent #aaa transparent;
+    animation: ${spin} 1.2s linear infinite;
+  }
+`
+
+const UploadButton = styled(FileUploadButton)<{ uploading: boolean }>`
+  flex: 1;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  color: #cccccc;
+  font-size: 14px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+
+  &:before {
+    content: '+';
+    font-size: 40px;
+    display: block;
+    height: 80px;
+    width: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #222222;
+    border-radius: 100px;
+    color: #666666;
+    box-sizing: border-box;
+  }
+
+  ${({ uploading }) => (uploading ? loadingMixin : '')}
+`
+
+const Thumbnail = styled.div`
+  flex: 1;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+`
+
+interface ImageGaleryProps {
+  onSelectedImage: (image: { cid: string; type: string }) => void
+}
+
+const ImageGalery: React.FC<ImageGaleryProps> = ({ onSelectedImage }) => {
+  const [images, addImage] = useImages()
+  const [uploading, setUploading] = useState(false)
+
+  return (
+    <div>
+      <Cards>
+        <UploadCard>
+          <UploadButton
+            uploading={uploading}
+            onUploadStart={() => setUploading(true)}
+            onUploaded={(cid: string, type: string, name: string) => {
+              addImage(cid, type, name)
+              onSelectedImage({ cid, type })
+              setUploading(false)
+            }}
+          />
+        </UploadCard>
+
+        {images.map((image: any) => (
+          <Card key={image.cid} onClick={() => onSelectedImage(image)}>
+            <Thumbnail style={{ backgroundImage: `url('${IPFS_GATEWAY}/ipfs/${image.cid}')` }} />
+            {image.filename}
+          </Card>
+        ))}
+      </Cards>
+    </div>
+  )
+}
+
+export default ImageGalery

--- a/components/SubgraphEditor/ImageLibrary/ImageLibrary.tsx
+++ b/components/SubgraphEditor/ImageLibrary/ImageLibrary.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react'
+import EditorModal from '../EditorModal'
+import ImagePreview from './ImagePreview'
+import ImageGalery from './ImageGalery'
+
+interface ImageLibraryProps {
+  open: boolean
+  close: () => void
+  editor?: any
+}
+
+const ImageLibrary: React.FC<ImageLibraryProps> = ({ open, close, editor }) => {
+  const [selectedImage, setSelectedImage] = useState<null | { cid: string; type: string }>(null)
+
+  useEffect(() => {
+    if (!open && selectedImage) {
+      setSelectedImage(null)
+    }
+  }, [open])
+
+  return (
+    <EditorModal
+      isOpen={open}
+      onClose={close}
+      title="Image Library"
+      buttons={[{ label: 'Return to Editor', onClick: close }]}
+      width="100%"
+      height="70%"
+      onBack={selectedImage ? () => setSelectedImage(null) : null}
+    >
+      {selectedImage ? (
+        <ImagePreview
+          editor={editor}
+          cid={selectedImage.cid}
+          type={selectedImage.type}
+          close={close}
+        />
+      ) : (
+        <ImageGalery onSelectedImage={setSelectedImage} />
+      )}
+    </EditorModal>
+  )
+}
+
+export default ImageLibrary

--- a/components/SubgraphEditor/ImageLibrary/ImagePreview.tsx
+++ b/components/SubgraphEditor/ImageLibrary/ImagePreview.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { IPFS_GATEWAY } from 'resources/constants'
+import DropdownButton from 'components/DropdownButton'
+
+const ImagePreviewContainer = styled.div`
+  height: 100px;
+  position: relative;
+  text-align: center;
+  margin: 10px 0;
+  width: 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+`
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+interface MetadataName {
+  code: string
+  name: string
+  whitespace: string
+  position: number
+}
+
+const NAME_REGEX = /\n(\s*)"?name"?:\s*(?:"|')([\w\d- ]+)(?:"|'),/g
+
+interface ImagePreviewProps {
+  editor: any
+  cid: string
+  type: string
+  close: () => void
+}
+
+const ImagePreview: React.FC<ImagePreviewProps> = ({ editor, cid, type, close }) => {
+  const [metadataNames, setMetadataNames] = useState<MetadataName[]>([])
+
+  useEffect(() => {
+    if (editor) {
+      const model = editor.getModel()
+      const value = model.getValue()
+
+      const metadataNames: MetadataName[] = []
+
+      let result
+      do {
+        result = NAME_REGEX.exec(value)
+        if (result) {
+          metadataNames.push({
+            code: result[0],
+            name: result[2],
+            whitespace: result[1],
+            position: result.index,
+          })
+        }
+      } while (result)
+
+      setMetadataNames(metadataNames)
+    }
+  }, [editor])
+
+  const options = metadataNames.map((name: MetadataName) => ({
+    value: name.name,
+    label: `Add to ${name.name}`,
+    onClick: () => {
+      const model = editor.getModel()
+      const currentCode = model.getValue()
+      const slicePoint = name.position + name.code.length
+      const newCode = `${currentCode.slice(0, slicePoint)}
+${name.whitespace}icon: sdk.ipfs.getDataURILoader('${cid}', '${type}'),${currentCode.slice(
+        slicePoint
+      )}`
+
+      model.setValue(newCode)
+      close()
+    },
+  }))
+
+  return (
+    <Container>
+      <ImagePreviewContainer style={{ backgroundImage: `url('${IPFS_GATEWAY}/ipfs/${cid}')` }} />
+
+      <div>{cid}</div>
+      <div>({type})</div>
+
+      <DropdownButton options={options} />
+    </Container>
+  )
+}
+
+export default ImagePreview

--- a/components/SubgraphEditor/NewAdapterForm.tsx
+++ b/components/SubgraphEditor/NewAdapterForm.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import styled from 'styled-components'
+import { newModule } from 'hooks/local-adapters'
+import { feeAdapter, apyAdapter } from 'resources/templates'
+import { usePlausible } from 'next-plausible'
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const TemplateSection = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const SectionLabel = styled.div``
+
+const TemplateList = styled.ul`
+  flex: 1;
+  max-height: 250px;
+  overflow: auto;
+  margin: 0;
+  padding: 0;
+`
+
+const Template = styled.li`
+  list-style: none;
+  margin: 8px;
+  padding: 16px;
+  border-radius: 5px;
+  border: solid 1px #6d6d6d;
+  cursor: pointer;
+
+  &:hover {
+    background: #3b3b3b;
+  }
+`
+
+const TemplateTitle = styled.div`
+  font-size: 16px;
+  font-weight: bold;
+`
+
+interface EmptyStateProps {
+  onAdapterSelection: (fileName: string) => void
+}
+
+const NewAdapterForm: React.FC<EmptyStateProps> = ({ onAdapterSelection }) => {
+  const plausible = usePlausible()
+
+  const createTemplateClickListener = (code: string, template: string) => () => {
+    plausible('new-adapter', {
+      props: {
+        template,
+      },
+    })
+
+    onAdapterSelection(newModule(code))
+  }
+
+  return (
+    <Container>
+      <TemplateSection>
+        <SectionLabel>From a template</SectionLabel>
+        <TemplateList>
+          <Template onClick={createTemplateClickListener(feeAdapter, 'fee')}>
+            <TemplateTitle>Fee Revenue Adapter</TemplateTitle>
+            <div>Create a basic adapter for querying fee revenue from a subgraph.</div>
+          </Template>
+          <Template onClick={createTemplateClickListener(apyAdapter, 'apy')}>
+            <TemplateTitle>APY Adapter</TemplateTitle>
+            <div>
+              Adapter for calculating the APY of an asset by comparing the exchange rate on 2 dates.
+            </div>
+          </Template>
+        </TemplateList>
+      </TemplateSection>
+    </Container>
+  )
+}
+
+export default NewAdapterForm

--- a/components/SubgraphEditor/PreviewPanel.tsx
+++ b/components/SubgraphEditor/PreviewPanel.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Adapter } from '@cryptostats/sdk'
+import { useCompiler } from 'hooks/compiler'
+import Attribute from '../Attribute'
+import SubAdapterPreview from './SubAdapterPreview'
+
+const Container = styled.div`
+  margin: 16px;
+`
+
+const SectionHeader = styled.div`
+  font-size: 14px;
+  color: #6b6b6b;
+  margin: 20px 0 16px;
+  text-transform: uppercase;
+`
+
+const PreviewPanel: React.FC = () => {
+  const { module, list, processing } = useCompiler()
+
+  if (!module) {
+    if (processing) {
+      return <div>Building adapter...</div>
+    } else {
+      return <div>Unable to build adapter</div>
+    }
+  }
+
+  return (
+    <Container>
+      {processing && <div>Building adapter...</div>}
+      <SectionHeader>Adapter Metadata</SectionHeader>
+      <Attribute name="Name">{module.name}</Attribute>
+      <Attribute name="Version">{module.version}</Attribute>
+      <Attribute name="License">{module.license}</Attribute>
+
+      <SectionHeader>Sub Adapters - {list?.adapters.length}</SectionHeader>
+      <div>
+        {list &&
+          list.adapters.map((adapter: Adapter) => (
+            <SubAdapterPreview
+              key={adapter.id}
+              subadapter={adapter}
+              openByDefault={list.adapters.length === 1}
+            />
+          ))}
+      </div>
+    </Container>
+  )
+}
+
+export default PreviewPanel

--- a/components/SubgraphEditor/PrimaryFooter.tsx
+++ b/components/SubgraphEditor/PrimaryFooter.tsx
@@ -1,0 +1,162 @@
+import React, { useState, Fragment } from 'react'
+import Link from 'next/link'
+import styled from 'styled-components'
+import { XOctagon, AlertTriangle, Info } from 'react-feather'
+import { useAdapter } from 'hooks/local-adapters'
+import PublishModal from './PublishModal'
+import { MarkerSeverity } from './types'
+import Button from 'components/Button'
+
+const Container = styled.div`
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+`
+
+const Side = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+const PublishButton = styled(Button)`
+  height: 35px;
+  margin: 0 16px 0 32px;
+  padding: 9px 20px;
+  border-radius: 4px;
+  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.5);
+  font-weight: normal;
+  position: relative;
+
+  &:disabled:hover:before {
+    content: 'Fix all errors to allow publishing';
+    display: block;
+    position: absolute;
+    z-index: 100;
+    left: 0;
+    transform: translateX(-140px);
+    top: 0;
+    bottom: 0;
+    background: #222222;
+    padding: 2px;
+    font-size: 12px;
+    border-radius: 4px;
+    color: #cccccc;
+  }
+`
+
+const IPFSLink = styled.a`
+  color: #eee;
+  font-size: 12px;
+`
+
+const ErrorChip = styled.button<{ color?: string }>`
+  background: #222222;
+  border-radius: 4px;
+  padding: 4px 8px;
+  color: ${({ color }) => color || '#7c8190'};
+  font-size: 12px;
+  margin: 4px;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    background: #191919;
+  }
+
+  svg {
+    margin-right: 4px;
+  }
+`
+
+interface PrimaryFooterProps {
+  fileName: string | null
+  markers: any[]
+  onMarkerClick: () => void
+  onConsoleClick: () => void
+  editorRef: any
+}
+
+const PrimaryFooter: React.FC<PrimaryFooterProps> = ({
+  fileName,
+  markers,
+  onMarkerClick,
+  onConsoleClick,
+  editorRef,
+}) => {
+  const [showModal, setShowModal] = useState(false)
+  const { adapter } = useAdapter(fileName)
+
+  const lastPublication =
+    adapter?.publications && adapter.publications.length > 0
+      ? adapter!.publications[adapter!.publications.length - 1]
+      : null
+
+  const infos = []
+  const warnings = []
+  const errors = []
+
+  for (const marker of markers) {
+    if (marker.severity === MarkerSeverity.Error) {
+      errors.push(marker)
+    } else if (marker.severity === MarkerSeverity.Warning) {
+      warnings.push(marker)
+    } else {
+      infos.push(marker)
+    }
+  }
+
+  return (
+    <Container>
+      <Side>
+        <ErrorChip onClick={onMarkerClick} color={infos.length > 0 ? '#cccccc' : undefined}>
+          <Info size={12} /> {infos.length}
+        </ErrorChip>
+        <ErrorChip onClick={onMarkerClick} color={warnings.length > 0 ? 'yellow' : undefined}>
+          <AlertTriangle size={12} /> {warnings.length}
+        </ErrorChip>
+        <ErrorChip onClick={onMarkerClick} color={errors.length > 0 ? 'red' : undefined}>
+          <XOctagon size={12} /> {errors.length}
+        </ErrorChip>
+        <ErrorChip onClick={onConsoleClick}>Console</ErrorChip>
+      </Side>
+
+      <Side>
+        {adapter && (
+          <Fragment>
+            {lastPublication && (
+              <Link href={`/discover/adapter/${lastPublication.cid}`} passHref>
+                <IPFSLink>
+                  Last published to IPFS as {lastPublication.cid.substr(0, 6)}...
+                  {lastPublication.cid.substr(-4)}
+                  {' (v'}
+                  {lastPublication.version})
+                </IPFSLink>
+              </Link>
+            )}
+
+            <PublishButton
+              onClick={() => setShowModal(true)}
+              disabled={errors.length > 0}
+              className={'primary'}
+            >
+              Publish to IPFS
+            </PublishButton>
+          </Fragment>
+        )}
+      </Side>
+
+      {fileName && (
+        <PublishModal
+          fileName={fileName}
+          show={showModal}
+          onClose={() => setShowModal(false)}
+          editorRef={editorRef}
+        />
+      )}
+    </Container>
+  )
+}
+
+export default PrimaryFooter

--- a/components/SubgraphEditor/PublishModal.tsx
+++ b/components/SubgraphEditor/PublishModal.tsx
@@ -1,0 +1,225 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import { useENSName } from 'use-ens-name'
+import { useWeb3React } from '@web3-react/core'
+import EditorModal, { Button as ModalButton } from './EditorModal'
+import { useAdapter } from 'hooks/local-adapters'
+import Button from 'components/Button'
+import WalletConnections from 'components/WalletConnections'
+import Text from 'components/Text'
+
+const AlignButtons = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`
+
+const ShareUrl = styled.div`
+  padding: 16px;
+  max-width: 100%;
+  overflow: hidden;
+  background-color: #222222;
+  border: 1px solid #444444;
+  border-radius: 4px;
+`
+
+interface PublishModalProps {
+  fileName: string
+  show: boolean
+  onClose: () => void
+  editorRef: any
+}
+
+const VERSION_NUM_REGEX = /([\d]+)\.([\d]+)\.([\d]+)/g
+
+enum STATE {
+  INIT,
+  SIGN,
+  SIGNED_PUBLISH_PENDING,
+  PUBLISHING,
+  PUBLISHED,
+}
+
+const PublishModal: React.FC<PublishModalProps> = ({ fileName, show, onClose, editorRef }) => {
+  const [state, setState] = useState(STATE.INIT)
+  const [cid, setCID] = useState<null | string>(null)
+  const [hash, setHash] = useState<null | string>(null)
+  const { publish: publishToIPFS, adapter, getSignableHash, save } = useAdapter(fileName)
+  const { account, library } = useWeb3React()
+  const accountName = useENSName(account, account)
+
+  const prepareSignature = async () => {
+    setState(STATE.SIGN)
+    const _hash = await getSignableHash()
+    setHash(_hash)
+  }
+
+  const sign = async () => {
+    setState(STATE.SIGNED_PUBLISH_PENDING)
+    try {
+      const signature = await library.getSigner().signMessage(hash)
+      setState(STATE.PUBLISHING)
+
+      const { codeCID } = await publishToIPFS({ signature, hash, signer: account })
+      setCID(codeCID)
+      setState(STATE.PUBLISHED)
+    } catch (e) {
+      console.warn(e)
+      setState(STATE.SIGN)
+    }
+  }
+
+  const lastPublication =
+    adapter?.publications && adapter.publications.length > 0
+      ? adapter!.publications[adapter!.publications.length - 1]
+      : null
+  const hasUpdatedVersion = !lastPublication || adapter?.version !== lastPublication.version
+
+  let patchVersion: string | null = null
+  let minorVersion: string | null = null
+  let majorVersion: string | null = null
+  let updateVersion: ((newVersion: string) => void) | null = null
+  const versionRegexResult = show && !hasUpdatedVersion && VERSION_NUM_REGEX.exec(adapter!.code)
+  if (versionRegexResult) {
+    const [version, major, minor, patch] = versionRegexResult
+
+    patchVersion = `${major}.${minor}.${parseInt(patch) + 1}`
+    minorVersion = `${major}.${parseInt(minor) + 1}.0`
+    majorVersion = `${parseInt(major) + 1}.0.0`
+
+    updateVersion = (newVersion: string) => {
+      const startLineNumber = adapter!.code.substr(0, versionRegexResult.index).split('\n').length
+      const startColumn = adapter!.code.split('\n')[startLineNumber - 1].indexOf(version) + 1
+      const endColumn = startColumn + version.length
+
+      const edit = {
+        range: { endColumn, endLineNumber: startLineNumber, startColumn, startLineNumber },
+        text: newVersion,
+      }
+
+      editorRef.current.executeEdits('version', [edit])
+      save(adapter!.code.replace(version, newVersion), adapter!.name, newVersion)
+    }
+  }
+
+  const close = () => {
+    onClose()
+    setState(STATE.INIT)
+    setCID(null)
+    setHash(null)
+  }
+
+  const returnButton = { label: 'Return to Editor', onClick: close }
+
+  let title = 'Publish Your Adapter on IPFS'
+  let buttons: ModalButton[] = []
+  let content = null
+
+  const disabled = state === STATE.SIGNED_PUBLISH_PENDING
+
+  if (show) {
+    switch (state) {
+      case STATE.INIT:
+        if (hasUpdatedVersion) {
+          buttons = [returnButton, { label: 'Continue', onClick: prepareSignature, disabled }]
+          content = (
+            <div>
+              <Text tag="p" color="white" type="description">
+                Publish your adapter to IPFS to make it viewable by the community.
+              </Text>
+              <Text tag="p" color="white" type="description">
+                Once your adapter is published, you can share it on the CryptoStats forum to request
+                verification.
+              </Text>
+            </div>
+          )
+        } else {
+          buttons = [returnButton]
+          content = (
+            <>
+              <Text tag="p" color="white" type="description">
+                This adapter has already been deployed with the current version{' '}
+                <strong>{adapter!.version}</strong>.
+              </Text>
+              <Text tag="p" color="white" type="description" mb="24">
+                Update the version number to allow publishing to IPFS.
+              </Text>
+              <AlignButtons>
+                <Button variant="outline" onClick={() => updateVersion!(patchVersion!)}>
+                  Small update: {patchVersion}
+                </Button>
+                <Button variant="outline" onClick={() => updateVersion!(minorVersion!)}>
+                  Medium update: {minorVersion}
+                </Button>
+                <Button variant="outline" onClick={() => updateVersion!(majorVersion!)}>
+                  Large update: {majorVersion}
+                </Button>
+              </AlignButtons>
+            </>
+          )
+        }
+        break
+
+      case STATE.SIGN:
+      case STATE.SIGNED_PUBLISH_PENDING:
+        buttons = [returnButton]
+        if (!account) {
+          content = (
+            <div>
+              <Text tag="p" color="white" type="description">
+                You need to connect your Web3 wallet to sign your adapter.
+              </Text>
+              <WalletConnections />
+            </div>
+          )
+        } else if (!hash) {
+          content = <div>Loading...</div>
+        } else {
+          buttons = [returnButton, { label: 'Sign adapter', onClick: sign, disabled }]
+          content = (
+            <div>
+              <Text tag="p" color="white" type="description">
+                Click "Sign Adapter" to sign your adapter code from your current account (
+                {accountName}).
+              </Text>
+            </div>
+          )
+        }
+        break
+
+      case STATE.PUBLISHING:
+        content = (
+          <div>
+            <Text tag="p" color="white" type="description">
+              Publishing to IPFS...
+            </Text>
+          </div>
+        )
+        break
+
+      case STATE.PUBLISHED:
+        title = '🎉  Adapter Successfully Published!'
+        buttons = [returnButton]
+        content = (
+          <div>
+            <Text tag="p" color="white" type="description">
+              Your adapter has been published to IPFS! You may now share the following link:
+            </Text>
+            <Text tag="p" type="label" mt="24" mb="16">
+              Adapter url
+            </Text>
+            <ShareUrl>https://cryptostats.community/discover/adapter/{cid}</ShareUrl>
+          </div>
+        )
+        break
+    }
+  }
+
+  return (
+    <EditorModal isOpen={show} onClose={close} title={title} buttons={buttons}>
+      {content}
+    </EditorModal>
+  )
+}
+
+export default PublishModal

--- a/components/SubgraphEditor/QueryForm.tsx
+++ b/components/SubgraphEditor/QueryForm.tsx
@@ -1,0 +1,185 @@
+import InputField from 'components/InputField'
+import { useEditorState } from 'hooks/editor-state'
+import { useConsole } from 'hooks/console'
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import { LOG_LEVEL } from '@cryptostats/sdk'
+import Button from 'components/Button'
+
+const Container = styled.div`
+  background-color: #444;
+  margin: 16px;
+  border-radius: 4px;
+`
+
+const TopBar = styled.div`
+  font-size: 14px;
+  padding: 12px 16px;
+  border-radius: 4px;
+  border-bottom: solid 1px #636363;
+
+  &:hover {
+    cursor: pointer;
+    background-color: #565656;
+  }
+`
+
+const QueryFormInfo = styled.div`
+  padding: 16px 16px 0;
+`
+
+const Result = styled.pre`
+  white-space: pre-wrap;
+  font-size: 16px;
+  font-weight: medium;
+  margin: 8px 0;
+`
+
+const InputBlock = styled.div`
+  padding: 16px 16px 0;
+`
+
+const Label = styled.div`
+  font-size: 14px;
+  color: #9d9d9d;
+`
+
+const Input = styled(InputField)`
+  width: 100%;
+  width: -webkit-fill-available;
+  padding: 8px 0px 8px 16px;
+  border-radius: 4px;
+  border: solid 1px #424242;
+  background-color: #1a1919;
+  font-size: 14px;
+  color: #b5b6b9;
+  margin-top: 8px;
+  outline: none;
+`
+
+const RunButton = styled(Button)`
+  padding: 10px 0;
+  background: #d6eaff;
+  color: #0477f4;
+  border: none;
+  border-radius: 4px;
+  text-align: center;
+
+  &:hover {
+    cursor: pointer;
+    color: #fff;
+    background-color: #0477f4;
+  }
+`
+
+const RunQueryBtn = styled.div`
+  padding: 24px 16px;
+`
+const Output = styled.div`
+  padding: 16px;
+  background-color: #000;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+`
+
+const Error = styled.div`
+  font-size: 14px;
+  color: #cf9b9b;
+`
+
+interface QueryProps {
+  id: string
+  fn: (...params: any[]) => Promise<any>
+  openByDefault?: boolean
+  storageKey: string
+}
+
+const functionToParamNames = (fn: Function) => {
+  const match = /\(((?:\w+, )*(?:\w+)?)\)/.exec(fn.toString())
+  return match ? match[1].split(',').map((name: string) => name.trim()) : []
+}
+
+enum STATUS {
+  READY,
+  RUNNING,
+  DONE,
+  ERROR,
+}
+
+interface State {
+  status: STATUS
+  result?: string
+  error?: string
+}
+
+const QueryForm: React.FC<QueryProps> = ({ id, fn, openByDefault, storageKey }) => {
+  const { addLine } = useConsole()
+  const [open, setOpen] = useEditorState(`${storageKey}-open`, !!openByDefault)
+  const [storedValues, setStoredValues] = useEditorState(
+    `${storageKey}-values`,
+    JSON.stringify([...new Array(fn.length)].map(() => ''))
+  )
+  const [state, setState] = useState<State>({
+    status: STATUS.READY,
+  })
+
+  const values = JSON.parse(storedValues)
+  const setValues = (newVals: string[]) => setStoredValues(JSON.stringify(newVals))
+
+  const functionNames = functionToParamNames(fn)
+
+  const execute = async () => {
+    setState({ status: STATUS.RUNNING })
+    try {
+      const result = await fn.apply(null, values)
+      setState({ status: STATUS.DONE, result })
+    } catch (e: any) {
+      setState({ status: STATUS.ERROR, error: e.message })
+      addLine({ level: LOG_LEVEL.ERROR.toString(), value: e.stack })
+    }
+  }
+
+  return (
+    <Container>
+      <TopBar onClick={() => setOpen(!open)}>{id}</TopBar>
+      {open && (
+        <div>
+          <>
+            <QueryFormInfo>
+              <Label>Fill the parameters below</Label>
+            </QueryFormInfo>
+            {[...new Array(fn.length)].map((_: any, index: number) => (
+              <InputBlock key={index}>
+                <Label>{functionNames[index]}</Label>
+                <Input
+                  value={values[index]}
+                  name={functionNames[index]}
+                  disabled={state.status === STATUS.RUNNING}
+                  onChange={(newValue: string) => {
+                    const newValues = [...values]
+                    newValues[index] = newValue
+                    setValues(newValues)
+                  }}
+                />
+              </InputBlock>
+            ))}
+          </>
+          <RunQueryBtn>
+            <RunButton onClick={execute} loading={state.status === STATUS.RUNNING} fullWidth>
+              Run Query
+            </RunButton>
+          </RunQueryBtn>
+          <Output>
+            <Label>Output</Label>
+            {state.error && <Error>Error: {state.error}</Error>}
+            {state.status === STATUS.DONE && (
+              <Result>{JSON.stringify(state.result, null, 2)}</Result>
+            )}
+          </Output>
+        </div>
+      )}
+    </Container>
+  )
+}
+
+export default QueryForm

--- a/components/SubgraphEditor/RightPanel.tsx
+++ b/components/SubgraphEditor/RightPanel.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Fill, Top } from 'react-spaces'
+import PreviewPanel from './PreviewPanel'
+import TestPanel from './TestPanel'
+import { useEditorState } from 'hooks/editor-state'
+
+const Container = styled(Fill)`
+  color: #ffffff;
+  background-color: #212121;
+`
+
+const Tabs = styled.ul`
+  display: flex;
+  margin: 0;
+  padding: 0;
+  height: 50px;
+`
+
+const Tab = styled.li<{ selected?: boolean }>`
+  list-style: none;
+  flex: 1;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  justify-content: center;
+
+  ${({ selected }) =>
+    !selected &&
+    `
+    background: #2f2f2f;
+    border-bottom: 1px solid #4A4A4D;
+    border-left: 1px solid #4A4A4D;
+    cursor: pointer;
+
+    &:hover {
+      background: #222222;
+    }
+  `}
+`
+
+const IconPreview = styled.i`
+  display: inline-block;
+  height: 16px;
+  width: 16px;
+  background-image: url('/Icon/View.svg');
+  background-position: center;
+  background-repeat: no-repeat;
+  margin-right: 8px;
+`
+const IconTest = styled.i`
+  display: inline-block;
+  height: 16px;
+  width: 16px;
+  background-image: url('/Icon/Flag.svg');
+  background-position: center;
+  background-repeat: no-repeat;
+  margin-right: 8px;
+`
+
+enum TAB {
+  PREVIEW,
+  TEST,
+}
+
+const RightPanel = () => {
+  const [tab, setTab] = useEditorState('right-tab', TAB.PREVIEW)
+
+  return (
+    <Container>
+      <Top size={50}>
+        <Tabs>
+          <Tab selected={tab === TAB.PREVIEW} onClick={() => setTab(TAB.PREVIEW)}>
+            <IconPreview /> Preview
+          </Tab>
+          <Tab selected={tab === TAB.TEST} onClick={() => setTab(TAB.TEST)}>
+            <IconTest /> Test
+          </Tab>
+        </Tabs>
+      </Top>
+      <Fill scrollable={tab === TAB.PREVIEW}>
+        {tab === TAB.PREVIEW ? <PreviewPanel /> : <TestPanel />}
+      </Fill>
+    </Container>
+  )
+}
+
+export default RightPanel

--- a/components/SubgraphEditor/SaveMessage.tsx
+++ b/components/SubgraphEditor/SaveMessage.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
+
+const SaveMessagePopup = styled.div`
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px;
+  background: rgb(239 37 37 / 70%);
+  border-radius: 4px;
+  top: 24px;
+  color: white;
+`
+
+const SaveMessage: React.FC = () => {
+  const [showSaveMessage, setShowSaveMessage] = useState(false)
+
+  useEffect(() => {
+    const saveBlocker = (e: any) => {
+      if ((e.metaKey || e.ctrlKey) && e.keyCode == 83) {
+        e.preventDefault()
+        setShowSaveMessage(true)
+        setTimeout(() => setShowSaveMessage(false), 5000)
+      }
+    }
+
+    window.document.addEventListener('keydown', saveBlocker, false)
+
+    return () => window.document.removeEventListener('keydown', saveBlocker)
+  }, [])
+
+  return (
+    <>
+      {showSaveMessage && <SaveMessagePopup>Your changes are saved automatically</SaveMessagePopup>}
+    </>
+  )
+}
+
+export default SaveMessage

--- a/components/SubgraphEditor/SubAdapterPreview.tsx
+++ b/components/SubgraphEditor/SubAdapterPreview.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import { Adapter } from '@cryptostats/sdk'
+import Attribute from '../Attribute'
+import { IPFS_GATEWAY } from 'resources/constants'
+
+const Container = styled.div``
+
+const Header = styled.div`
+  border-top: solid 1px #4a4a4d;
+  border-bottom: solid 1px #4a4a4d;
+  padding: 16px;
+  background: #2f2f2f;
+  margin: 0 -16px;
+  cursor: pointer;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    background: #262626;
+  }
+`
+
+const Body = styled.div`
+  padding: var(--spaces-4) var(--spaces-2);
+`
+
+const Value = styled.pre`
+  white-space: pre-wrap;
+  margin: 4px 0 10px;
+  font-size: 14px;
+`
+
+const Icon = styled.img<{ size?: string }>`
+  width: auto;
+  margin-right: 16px;
+
+  ${({ size }) =>
+    size === 'small'
+      ? `
+    max-height: 16px;
+    margin-right: 16px;
+  `
+      : ``}
+  ${({ size }) =>
+    size === 'large'
+      ? `
+    max-height: 32px;
+    margin-right: 32px;
+  `
+      : ``}
+`
+
+interface SubAdapterPreviewProps {
+  subadapter: Adapter
+  openByDefault: boolean
+}
+
+const SubAdapterPreview: React.FC<SubAdapterPreviewProps> = ({ subadapter, openByDefault }) => {
+  const [open, setOpen] = useState(openByDefault)
+
+  // @ts-ignore
+  const { name, ...metadata } = subadapter.metadata.metadata
+
+  if (!open) {
+    return (
+      <Header onClick={() => setOpen(true)}>
+        {metadata.icon?.cid && (
+          <Icon size="small" src={`${IPFS_GATEWAY}/ipfs/${metadata.icon.cid}`} />
+        )}
+        {name || subadapter.id}
+        {metadata.subtitle ? ` - ${metadata.subtitle}` : null}
+      </Header>
+    )
+  }
+
+  return (
+    <Container>
+      <Header onClick={() => setOpen(false)}>
+        {metadata.icon?.cid && (
+          <Icon size="small" src={`${IPFS_GATEWAY}/ipfs/${metadata.icon.cid}`} />
+        )}
+        {name || subadapter.id}
+        {metadata.subtitle ? ` - ${metadata.subtitle}` : null}
+      </Header>
+
+      <Body>
+        {Object.entries(metadata).map(([key, val]: [string, any]) => (
+          <Attribute name={key} key={key}>
+            {val?.cid ? (
+              <div>
+                <Icon size="large" src={`${IPFS_GATEWAY}/ipfs/${val.cid}`} />
+              </div>
+            ) : (
+              <Value>{JSON.stringify(val, null, 2)}</Value>
+            )}
+          </Attribute>
+        ))}
+      </Body>
+    </Container>
+  )
+}
+
+export default SubAdapterPreview

--- a/components/SubgraphEditor/SubAdapterTest.tsx
+++ b/components/SubgraphEditor/SubAdapterTest.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Adapter } from '@cryptostats/sdk'
+import QueryForm from './QueryForm'
+import { useEditorState } from 'hooks/editor-state'
+
+const Container = styled.div``
+
+const Header = styled.div`
+  border-top: solid 1px #4a4a4d;
+  border-bottom: solid 1px #4a4a4d;
+  padding: 16px;
+  background: #2f2f2f;
+  cursor: pointer;
+
+  &:hover {
+    background: #262626;
+  }
+`
+
+const Icon = styled.img<{ size?: string }>`
+  width: auto;
+  margin-right: 16px;
+
+  ${({ size }) =>
+    size === 'small'
+      ? `
+    max-height: 16px;
+    margin-right: 16px;
+  `
+      : ``}
+  ${({ size }) =>
+    size === 'large'
+      ? `
+    max-height: 32px;
+    margin-right: 32px;
+  `
+      : ``}
+`
+
+interface SubAdapterPreviewProps {
+  subadapter: Adapter
+  openByDefault: boolean
+}
+
+const SubAdapterTest: React.FC<SubAdapterPreviewProps> = ({ subadapter, openByDefault }) => {
+  const [fileName] = useEditorState<string>('open-file')
+  const [open, setOpen] = useEditorState(`subtest-${fileName}-${subadapter.id}-open`, openByDefault)
+
+  // @ts-ignore
+  const { name, subtitle, ...metadata } = subadapter.metadata.metadata
+
+  if (!open) {
+    return (
+      <Header onClick={() => setOpen(true)}>
+        {metadata.icon?.cid && (
+          <Icon size="small" src={`https://gateway.pinata.cloud/ipfs/${metadata.icon.cid}`} />
+        )}
+        {name || subadapter.id}
+        {subtitle ? ` - ${subtitle}` : null}
+      </Header>
+    )
+  }
+
+  const queries = Object.entries(subadapter.queries)
+
+  return (
+    <Container>
+      <Header onClick={() => setOpen(false)}>
+        {metadata.icon?.cid && (
+          <Icon size="small" src={`https://gateway.pinata.cloud/ipfs/${metadata.icon.cid}`} />
+        )}
+        {name || subadapter.id}
+        {subtitle ? ` - ${subtitle}` : null}
+      </Header>
+
+      <div>
+        {queries.map(([queryName, fn]: [string, (...params: any[]) => Promise<any>]) => (
+          <QueryForm
+            key={queryName}
+            id={queryName}
+            storageKey={`subtest-${fileName}-${subadapter.id}-${queryName}`}
+            fn={fn}
+            openByDefault={queries.length === 1}
+          />
+        ))}
+      </div>
+    </Container>
+  )
+}
+
+export default SubAdapterTest

--- a/components/SubgraphEditor/Tabs.tsx
+++ b/components/SubgraphEditor/Tabs.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import styled from 'styled-components'
+import CloseIcon from 'components/CloseIcon'
+import { FileData } from 'hooks/local-subgraphs'
+
+const TabRow = styled.div`
+  display: flex;
+  flex: 1;
+`
+
+const Tab = styled.div<{ $focused: boolean }>`
+  display: flex;
+  font-size: 16px;
+  font-weight: medium;
+  color: #ffffff;
+  background: #212121;
+  align-items: center;
+  padding: 0 16px;
+  opacity: ${props => (props.$focused ? '1' : 0.5)};
+
+  &:hover {
+    cursor: pointer;
+  }
+`
+
+const CloseButton = styled.button`
+  border: none;
+  background: transparent;
+  margin-left: 24px;
+  cursor: pointer;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+
+  & svg {
+    fill: #888888;
+  }
+  &:hover svg {
+    fill: #666666;
+  }
+`
+
+export interface TabState {
+  type: 'schema' | 'mapping'
+  fileId?: string | null
+  open: boolean
+  focused: boolean
+}
+
+interface TabsProps {
+  current?: string | null
+  onClose?: (fileId?: string) => void
+  onSelect: (fileId?: string) => void
+  openTabs: (TabState & { fileData?: FileData })[]
+}
+
+export const Tabs = ({ onClose, openTabs, onSelect }: TabsProps) => {
+  return (
+    <TabRow>
+      {openTabs.map(ot => (
+        <Tab key={ot.fileId} $focused={ot.focused} onClick={() => onSelect(ot.fileId!)}>
+          <div>{ot.fileData?.name || ''}</div>
+          {ot.focused && onClose && (
+            <CloseButton onClick={() => onClose(ot.fileId!)}>
+              <CloseIcon />
+            </CloseButton>
+          )}
+        </Tab>
+      ))}
+    </TabRow>
+  )
+}
+
+export default Tabs

--- a/components/SubgraphEditor/TestPanel.tsx
+++ b/components/SubgraphEditor/TestPanel.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Fill } from 'react-spaces'
+import { Adapter } from '@cryptostats/sdk'
+import { useCompiler } from 'hooks/compiler'
+import SubAdapterTest from './SubAdapterTest'
+
+const Container = styled(Fill)`
+  > .spaces-resize-handle {
+    border-top: solid 2px #4a4a4d;
+    box-sizing: border-box;
+  }
+`
+
+const Main = styled(Fill)``
+
+const Label = styled.div`
+  font-size: 14px;
+  color: #6b6b6b;
+  letter-spacing: 1.1px;
+  text-transform: uppercase;
+  margin: 16px;
+`
+
+const TabContentIntro = styled.div`
+  font-size: 14px;
+  color: #808080;
+  line-height: 19px;
+  margin: 16px 16px 24px;
+`
+
+const PreviewPanel: React.FC = () => {
+  const { module, list, processing } = useCompiler()
+
+  if (!module) {
+    if (processing) {
+      return <div>Building adapter...</div>
+    } else {
+      return <div>Unable to build adapter</div>
+    }
+  }
+
+  return (
+    <Container>
+      <Main scrollable={true}>
+        <TabContentIntro>
+          In order to publish your Adapter you need to test the query you wrote.
+        </TabContentIntro>
+        <Label>Queries to test</Label>
+        {list &&
+          list.adapters.map((adapter: Adapter) => (
+            <SubAdapterTest
+              key={adapter.id}
+              subadapter={adapter}
+              openByDefault={list.adapters.length === 1}
+            />
+          ))}
+      </Main>
+    </Container>
+  )
+}
+
+export default PreviewPanel

--- a/components/SubgraphEditor/index.ts
+++ b/components/SubgraphEditor/index.ts
@@ -1,0 +1,1 @@
+export { default as default } from './Editor'

--- a/components/SubgraphEditor/types.ts
+++ b/components/SubgraphEditor/types.ts
@@ -1,0 +1,6 @@
+export enum MarkerSeverity {
+  Hint = 1,
+  Info = 2,
+  Warning = 4,
+  Error = 8,
+}

--- a/hooks/gql-compiler.tsx
+++ b/hooks/gql-compiler.tsx
@@ -1,0 +1,91 @@
+import React, { useContext, useEffect, useState } from 'react'
+import { Collection, Module, LOG_LEVEL } from '@cryptostats/sdk'
+import { compileTsToJs } from 'utils/ts-compiler'
+import { getSDK } from 'utils/sdk'
+
+import { getDiagnostics } from 'graphql-language-service-interface'
+
+interface CompilerState {
+  code: string | null
+  compiledCode: string | null
+  list: Collection | null
+  module: Module | null
+  error: string | null
+  processing: boolean
+}
+
+const DEFAULT_STATE = {
+  code: null,
+  compiledCode: null,
+  list: null,
+  module: null,
+  error: null,
+  processing: false,
+}
+
+const CompilerContext = React.createContext<{
+  state: CompilerState
+  setState(state: CompilerState): void
+}>({
+  state: DEFAULT_STATE,
+
+  setState() {
+    throw new Error('Not initialized')
+  },
+})
+
+interface EvaluateParams {
+  code: string
+  isTS?: boolean
+  onLog?: (level: LOG_LEVEL, ...args: any[]) => void
+}
+
+export const useGqlCompiler = () => {
+  const { state, setState } = useContext(CompilerContext)
+
+  const evaluate = async ({ code, isTS, onLog }: EvaluateParams) => {
+    setState({ ...DEFAULT_STATE, code, processing: true })
+
+    const sdk = getSDK({ onLog })
+
+    const list = sdk.getCollection('test')
+
+    try {
+      let compiledCode = null
+      if (isTS) {
+        compiledCode = await compileTsToJs(code)
+      }
+      const module = list.addAdaptersWithCode(compiledCode || code)
+
+      setState({ ...DEFAULT_STATE, code, module, compiledCode, list })
+    } catch (e) {
+      console.warn(e)
+      setState({ ...DEFAULT_STATE, error: e.message })
+    }
+  }
+
+  return { ...state, evaluate }
+}
+
+export const CompilerProvider: React.FC = ({ children }) => {
+  const [state, _setState] = useState<CompilerState>(DEFAULT_STATE)
+
+  const setState = (newState: CompilerState) =>
+    _setState((oldState: CompilerState) => {
+      if (oldState.list && oldState.list !== newState.list) {
+        oldState.list.cleanupModules()
+      }
+
+      return newState
+    })
+
+  useEffect(() => {
+    return () => {
+      if (state.list) {
+        state.list.cleanupModules()
+      }
+    }
+  }, [])
+
+  return <CompilerContext.Provider value={{ state, setState }}>{children}</CompilerContext.Provider>
+}

--- a/hooks/gql-compiler.tsx
+++ b/hooks/gql-compiler.tsx
@@ -3,7 +3,7 @@ import { Collection, Module, LOG_LEVEL } from '@cryptostats/sdk'
 import { compileTsToJs } from 'utils/ts-compiler'
 import { getSDK } from 'utils/sdk'
 
-import { getDiagnostics } from 'graphql-language-service-interface'
+// import { getDiagnostics } from 'graphql-language-service-interface'
 
 interface CompilerState {
   code: string | null

--- a/hooks/local-subgraphs.ts
+++ b/hooks/local-subgraphs.ts
@@ -102,9 +102,9 @@ export const useSubgraph = () => {
   }
 
   const publish = async ({
-    signature,
-    hash,
-    signer,
+    // signature,
+    // hash,
+    // signer,
   }: { signature?: string; signer?: string | null; hash?: string | null } = {}) => {
     // if (!id) {
     //   throw new Error('ID not set')

--- a/hooks/local-subgraphs.ts
+++ b/hooks/local-subgraphs.ts
@@ -1,0 +1,185 @@
+import { useEffect, useState } from 'react'
+// @ts-ignore
+import sampleModule from '!raw-loader!../components/sample-module.txt'
+
+const storageKey = 'localSubgraphs'
+
+interface Publication {
+  cid: string
+  version: string
+}
+
+export interface FileData {
+  code: string
+  name: string | null
+  version: string | null
+  publications: Publication[]
+}
+
+export interface AdapterWithID extends Adapter {
+  id: string
+}
+
+const getStorage = () =>
+  typeof window === 'undefined' ? {} : JSON.parse(window.localStorage.getItem(storageKey) || '{}')
+
+export const getStorageItem = (id: string) => getStorage()[id] || null
+
+const setStorageItem = (id: string, value: any) => {
+  window.localStorage.setItem(
+    storageKey,
+    JSON.stringify({
+      ...getStorage(),
+      [id]: value,
+    })
+  )
+  updateAdapterLists()
+}
+
+const adapterListUpdaters: Function[] = []
+
+const updateAdapterLists = () => adapterListUpdaters.map(updater => updater())
+
+export const useAdapterList = (): AdapterWithID[] => {
+  const _update = useState({})[1]
+  const update = () => _update({})
+
+  useEffect(() => {
+    adapterListUpdaters.push(update)
+
+    return () => void adapterListUpdaters.splice(adapterListUpdaters.indexOf(update), 1)
+  }, [])
+
+  const list = Object.entries(getStorage()).map(([id, adapter]: [string, any]) => ({
+    ...adapter,
+    id,
+  }))
+
+  return list
+}
+
+const randomId = () => Math.floor(Math.random() * 1000000).toString(16)
+
+interface NewModuleProps {
+  code: string
+  publications?: Publication[]
+  name?: string
+}
+
+export const newModule = ({
+  name = 'New Module',
+  code = sampleModule,
+  publications = [],
+}: NewModuleProps) => {
+  const id = randomId()
+
+  const adapter: FileData = {
+    code,
+    name,
+    publications,
+    version: null,
+  }
+
+  setStorageItem(id, adapter)
+  return id
+}
+
+export const useSubgraph = () => {
+  const update = useState({})[1]
+
+  const save = (id: string, code: string, name: string | null, version: string | null) => {
+    if (!id) {
+      throw new Error('ID not set')
+    }
+
+    const adapter = getStorageItem(id)
+
+    const newAdapter: Adapter = { ...adapter, code, name, version }
+    setStorageItem(id, newAdapter)
+    update({})
+
+    return id
+  }
+
+  const publish = async ({
+    signature,
+    hash,
+    signer,
+  }: { signature?: string; signer?: string | null; hash?: string | null } = {}) => {
+    // if (!id) {
+    //   throw new Error('ID not set')
+    // }
+    // const adapter = getStorageItem(id)
+    // const previousVersion =
+    //   adapter?.publications && adapter.publications.length > 0
+    //     ? adapter.publications[adapter.publications.length - 1]
+    //     : null
+    // if (previousVersion && adapter.version === previousVersion.version) {
+    //   throw new Error(`Version ${adapter.version} is already published`)
+    // }
+    // const req = await fetch('/api/upload-adapter', {
+    //   method: 'POST',
+    //   headers: {
+    //     'Content-type': 'application/json',
+    //   },
+    //   body: JSON.stringify({
+    //     code: adapter.code,
+    //     version: adapter.version,
+    //     previousVersion: previousVersion?.cid || null,
+    //     language: 'typescript',
+    //     signature,
+    //     hash,
+    //     signer,
+    //   }),
+    // })
+    // const response = await req.json()
+    // if (!response.success) {
+    //   throw new Error(response.error)
+    // }
+    // const newAdapter: Adapter = {
+    //   ...adapter,
+    //   code: adapter.code,
+    //   name: adapter.name,
+    //   publications: [
+    //     ...(adapter.publications || []),
+    //     { cid: response.codeCID, version: adapter.version, signature },
+    //   ],
+    // }
+    // setStorageItem(id, newAdapter)
+    // update({})
+    // return response
+  }
+
+  const getSignableHash = async () => {
+    // if (!id) {
+    //   throw new Error('ID not set')
+    // }
+    // const adapter = getStorageItem(id)
+    // const previousVersion =
+    //   adapter?.publications && adapter.publications.length > 0
+    //     ? adapter.publications[adapter.publications.length - 1]
+    //     : null
+    // if (previousVersion && adapter.version === previousVersion.version) {
+    //   throw new Error(`Version ${adapter.version} is already published`)
+    // }
+    // const req = await fetch('/api/prepare-adapter', {
+    //   method: 'POST',
+    //   headers: {
+    //     'Content-type': 'application/json',
+    //   },
+    //   body: JSON.stringify({
+    //     code: adapter.code,
+    //     version: adapter.version,
+    //     previousVersion: previousVersion?.cid || null,
+    //     language: 'typescript',
+    //   }),
+    // })
+    // const { hash } = await req.json()
+    // const message = `CryptoStats Adapter Hash: ${hash}`
+    // return message
+  }
+
+  const getDataFile = (id: string) => getStorageItem(id)
+
+  return { save, publish, getSignableHash, getDataFile }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,7 @@ import { setENSCache } from 'use-ens-name'
 const GlobalStyle = createGlobalStyle`
   :root {
 
-    // Colors 
+    // Colors
     --color-primary: #0477F4;
     --color-primary-100: #BDD0F6;
     --color-primary-200: #D6EAFF;
@@ -27,7 +27,7 @@ const GlobalStyle = createGlobalStyle`
     --color-dark-500: #282D36;
     --color-dark-600: #505050;
     --color-dark-700: #878787;
- 
+
     --color-palette-1: #D0E0FF;
     --color-palette-2: #FFE3D0;
     --color-palette-3: #FFFDD0;
@@ -112,16 +112,11 @@ const App: React.FC<AppProps> = ({ Component, pageProps }) => {
         <link rel="icon" type="image/x-icon" href="/favicon.png" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@100;300;400;500;600;700&display=swap"
-          rel="stylesheet"
-        />
       </Head>
 
       <GlobalStyle />
       <Web3ReactProvider
-        getLibrary={(provider: any) => new ethers.providers.Web3Provider(provider)}
-      >
+        getLibrary={(provider: any) => new ethers.providers.Web3Provider(provider)}>
         <PlausibleProvider domain="cryptostats.community">
           <Component {...pageProps} />
         </PlausibleProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -112,6 +112,10 @@ const App: React.FC<AppProps> = ({ Component, pageProps }) => {
         <link rel="icon" type="image/x-icon" href="/favicon.png" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@100;300;400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
       </Head>
 
       <GlobalStyle />

--- a/pages/editor/subgraph.tsx
+++ b/pages/editor/subgraph.tsx
@@ -1,0 +1,16 @@
+import { NextPage } from 'next'
+import SubgraphEditor from 'components/SubgraphEditor'
+import { CompilerProvider } from 'hooks/compiler'
+import { ConsoleProvider } from 'hooks/console'
+
+const SubgraphEditorPage: NextPage = () => {
+  return (
+    <ConsoleProvider>
+      <CompilerProvider>
+        <SubgraphEditor />
+      </CompilerProvider>
+    </ConsoleProvider>
+  )
+}
+
+export default SubgraphEditorPage

--- a/resources/templates/empty-mapping.txt
+++ b/resources/templates/empty-mapping.txt
@@ -1,0 +1,6 @@
+export const name = 'New Module';
+export const version = '0.0.1';
+export const license = 'MIT';
+
+export function setup(sdk: Context) {
+}

--- a/resources/templates/empty-schema.txt
+++ b/resources/templates/empty-schema.txt
@@ -1,0 +1,9 @@
+type Book {
+  title: String
+  author: Author
+}
+
+type Author {
+  name: String
+  books: [Book]
+}

--- a/resources/templates/index.ts
+++ b/resources/templates/index.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck
 export { default as emptyAdapter } from '!raw-loader!./empty-adapter.txt'
+export { default as emptyMapping } from '!raw-loader!./empty-mapping.txt'
+export { default as emptySchema } from '!raw-loader!./empty-schema.txt'
 export { default as feeAdapter } from '!raw-loader!./fee-adapter.txt'
 export { default as apyAdapter } from '!raw-loader!./apy-adapter.txt'


### PR DESCRIPTION
I have an initial version ready with the following feature:

* 2 tabs open when you open the editor, these should be loaded from memory/IPFS ideally
* Being able to change focus, changes get saved into localstorage
* Support for gql in the CodeEditor component. Note that there is no validation for the schema, only color highlights

I did not add the possibility to close the tab, as for that we would need to have a way to see what can be opened. With 2 files only we might not even need this, it will be relevant when there are more.

Probably it's not the best to merge this into `main`, we could create a `feature/subgraph-builder` branch, and merge all the updates there?