### PR TITLE
Add data structure for subgraphs

### DIFF
--- a/components/SubgraphEditor/Tabs.tsx
+++ b/components/SubgraphEditor/Tabs.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import CloseIcon from 'components/CloseIcon'
-import { FileData } from 'hooks/local-subgraphs'
 
 const TabRow = styled.div`
   display: flex;
@@ -42,6 +41,7 @@ const CloseButton = styled.button`
 
 export interface TabState {
   type: 'schema' | 'mapping'
+  name?: string
   fileId?: string | null
   open: boolean
   focused: boolean
@@ -51,7 +51,7 @@ interface TabsProps {
   current?: string | null
   onClose?: (fileId?: string) => void
   onSelect: (fileId?: string) => void
-  openTabs: (TabState & { fileData?: FileData })[]
+  openTabs: TabState[]
 }
 
 export const Tabs = ({ onClose, openTabs, onSelect }: TabsProps) => {
@@ -59,7 +59,7 @@ export const Tabs = ({ onClose, openTabs, onSelect }: TabsProps) => {
     <TabRow>
       {openTabs.map(ot => (
         <Tab key={ot.fileId} $focused={ot.focused} onClick={() => onSelect(ot.fileId!)}>
-          <div>{ot.fileData?.name || ''}</div>
+          <div>{ot.name || ot.fileId || 'File'}</div>
           {ot.focused && onClose && (
             <CloseButton onClick={() => onClose(ot.fileId!)}>
               <CloseIcon />

--- a/hooks/gql-compiler.tsx
+++ b/hooks/gql-compiler.tsx
@@ -58,7 +58,7 @@ export const useGqlCompiler = () => {
       const module = list.addAdaptersWithCode(compiledCode || code)
 
       setState({ ...DEFAULT_STATE, code, module, compiledCode, list })
-    } catch (e) {
+    } catch (e: any) {
       console.warn(e)
       setState({ ...DEFAULT_STATE, error: e.message })
     }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -120,7 +120,8 @@ const App: React.FC<AppProps> = ({ Component, pageProps }) => {
 
       <GlobalStyle />
       <Web3ReactProvider
-        getLibrary={(provider: any) => new ethers.providers.Web3Provider(provider)}>
+        getLibrary={(provider: any) => new ethers.providers.Web3Provider(provider)}
+      >
         <PlausibleProvider domain="cryptostats.community">
           <Component {...pageProps} />
         </PlausibleProvider>


### PR DESCRIPTION
Copys some of the structure from #6.

The primary change is that we're storing each subgraph "project" as a single entity in storage, as opposed to storing individual files. Each subgraph project includes one schema, one or more mappings, as well as metadata such as the contracts.