### PR TITLE
Use Miniscan for fetching ABI/block num

### DIFF
--- a/components/NewSubgraph/SelectedContract.tsx
+++ b/components/NewSubgraph/SelectedContract.tsx
@@ -147,14 +147,14 @@ export const SelectedContract = (props: SelectedContractProps) => {
   ])
 
   const fetchMetadata = async () => {
-    const metadataReq = await fetch(`/api/etherscan/${addresses[CHAIN_ID]}/metadata`)
+    const metadataReq = await fetch(`https://miniscan.xyz/api/contract?network=ethereum&address=${addresses[CHAIN_ID]}`)
     const metadata = await metadataReq.json()
 
-    if (metadata.isContract) {
+    if (!metadata.error) {
       updateContract(addresses[CHAIN_ID], {
-        abi: metadata.abi,
-        startBlocks: { [CHAIN_ID]: metadata.deployBlock },
-        name: metadata.name,
+        abi: JSON.parse(metadata.data.ABI),
+        startBlocks: { [CHAIN_ID]: parseInt(metadata.data.StartBlock) },
+        name: metadata.data.ContractName,
       })
     } else if (metadata.success === false) {
       updateContract(addresses[CHAIN_ID], {


### PR DESCRIPTION
Been chatting with @_0xbe1, who built miniscan.xyz

They've built a simple API that supports all our needs for fetching ABIs from Etherscan, so I think it's worth using their API directly and supporting their site as a public-good.