### PR TITLE
Fix AS compilation on Vercel, loading all libraries into memory

### DIFF
--- a/pages/api/graph/compile-as.ts
+++ b/pages/api/graph/compile-as.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { handleErrors } from 'utils/api-endpoints'
 import * as asc from '@graphprotocol/graph-cli/node_modules/assemblyscript/cli/asc'
-import * as fs from 'fs'
+import graphLibFiles from 'resources/graph-ts-lib'
 
 const createExitHandler = (inputFile: string) => () => {
   throw new Error(`The AssemblyScript compiler crashed when compiling this file: '${inputFile}'
@@ -75,20 +75,11 @@ const compile = (inputFile: string, libraries: { [fileName: string]: string }) =
           return libraries[name]
         }
 
-        if (
-          name.indexOf('node_modules/@graphprotocol/graph-ts') === 0 &&
-          name.indexOf('..') === -1
-        ) {
-          const file = fs.readFileSync(`${process.env.PWD}/${name}`, { encoding: 'utf-8' })
-          console.log('found', name)
-          return file
+        if (name.indexOf('node_modules/@graphprotocol/graph-ts') === 0) {
+          return graphLibFiles[name]
         }
-        if (name.indexOf('@graphprotocol/graph-ts') === 0 && name.indexOf('..') === -1) {
-          const file = fs.readFileSync(`${process.env.PWD}/node_modules/${name}`, {
-            encoding: 'utf-8',
-          })
-          console.log('found', name)
-          return file
+        if (name.indexOf('@graphprotocol/graph-ts') === 0) {
+          return graphLibFiles[`node_modules/${name}`]
         }
       } catch (e) {
         return null

--- a/resources/graph-ts-lib.ts
+++ b/resources/graph-ts-lib.ts
@@ -1,0 +1,17 @@
+// This file loads all AssemblyScript files from the @graphprotocol/graph-ts package into memory,
+// and puts them into a mapping by their filename.
+
+// @ts-ignore
+const context = require.context(
+  '!raw-loader!node_modules/@graphprotocol/graph-ts',
+  true,
+  /node_modules\/@graphprotocol\/graph-ts.+\.ts$/
+)
+
+const graphLibFiles: { [fileName: string]: string } = {}
+
+for (let filename of context.keys()) {
+  graphLibFiles[filename] = context(filename).default
+}
+
+export default graphLibFiles

--- a/utils/api-endpoints.ts
+++ b/utils/api-endpoints.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 export const handleErrors =
   (fn: (req: NextApiRequest, res: NextApiResponse) => Promise<void>) =>
   (req: NextApiRequest, res: NextApiResponse) => {
-    fn(req, res).catch((error: any) =>
+    return fn(req, res).catch((error: any) =>
       res.status(400).json({
         success: false,
         error: error.message,

--- a/utils/as-compiler.ts
+++ b/utils/as-compiler.ts
@@ -1,16 +1,6 @@
 // @ts-ignore
 import asc from 'assemblyscript/asc'
-// @ts-ignore
-const context = require.context(
-  '!raw-loader!node_modules/@graphprotocol/graph-ts',
-  true,
-  /node_modules\/@graphprotocol\/graph-ts.+\.ts$/
-)
-const files: any = {}
-
-for (let filename of context.keys()) {
-  files[filename] = context(filename)
-}
+import files from 'resources/graph-ts-lib'
 
 interface CompilerOptions {
   libraries?: { [name: string]: string }
@@ -42,7 +32,7 @@ export async function compileAs(tsCode: string, { libraries }: CompilerOptions =
 
       const path = name.charAt(0) === '/' ? name.substring(1) : name
       if (path in files) {
-        return files[path].default
+        return files[path]
       }
       return null
     },


### PR DESCRIPTION
Currently, the compile-as API only works in development mode, due to the way Vercel handles filesystems.

This change loads all graph-ts libraries into memory, removing the need to load them from the filesystem while compiling